### PR TITLE
Update client.lua

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -93,9 +93,16 @@ function StartSelling(playerPed, drug)
     selling = true
 
     ESX.TriggerServerCallback('sell_drugs:getPlayerInventory', function(inventory)
-        local playerItem = GetItemFromInventory(inventory, drug.name)
+        local drugToSell = nil
 
-        if playerItem then
+        for _, drug in ipairs(Config.Drugs) do
+            if GetItemFromInventory(inventory, drug.name) then
+                drugToSell = drug
+                break 
+            end
+        end
+
+        if drugToSell then
             local pedCoords = GetEntityCoords(playerPed)
             local spawnCoords = GetRandomSpawnPoint(pedCoords, Config.SpawnRadius)
 
@@ -141,7 +148,7 @@ function StartSelling(playerPed, drug)
                             icon = "fas fa-cannabis",
                             onSelect = function()
                                 StartSellingAnimation(currentPed)
-                                SellDrug(drug)
+                                SellDrug(drugToSell)
                             end,
                             canInteract = function(entity)
                                 return true
@@ -174,7 +181,7 @@ function StartSelling(playerPed, drug)
                                         selling = false
                                         RemoveBlip(currentBlip)
                                     else
-                                        SellDrug(drug)
+                                        SellDrug(drugToSell)
                                     end
 
                                     break
@@ -189,10 +196,11 @@ function StartSelling(playerPed, drug)
                 SendNotification("Impossible de trouver un point de spawn valide.", "error")
             end
         else
-            SendNotification("Vous n'avez plus de drogue sur vous.", "error")
+            SendNotification("Vous n'avez pas de drogue sur vous.", "warning")
         end
     end)
 end
+
 
 function GetRandomSpawnPoint(playerCoords, radius)
     local attempts = 0


### PR DESCRIPTION
### Patch Note - Correction du système de gestion de vente de drogues

**Version :** 1.1.1  
**Date :** 12 octobre 2024

#### Changements principaux :

1. **Correction de la gestion des ventes multiples de drogues :**
   - La fonction de vente multiple de drogues a été corrigée pour gérer correctement les cas où le joueur possède plusieurs types de drogues dans son inventaire.
   - La logique de détection des drogues a été ajustée pour que le script n'arrête plus de parcourir l'inventaire après la première vente. Désormais, il est possible de vendre plusieurs types de drogues sans devoir redémarrer le script.

2. **Correction du comportement lors de l'ajout d'une seconde drogue :**
   - Avant cette mise à jour, si une seconde drogue était ajoutée dans la configuration, le joueur ne pouvait effectuer qu'une seule vente. Il devait ensuite redémarrer le script pour pouvoir continuer à vendre. Ce problème a été corrigé pour permettre des ventes consécutives sans nécessiter de redémarrage du script.

3. **Amélioration de la notification :**
   - Si aucune drogue n'est trouvée, une notification est correctement envoyée pour informer le joueur qu'il ne possède pas de drogue dans son inventaire.

#### Bugfixes :
- Correction d'un bug où la gestion des drogues dans l'inventaire n'était pas correctement traitée, empêchant la vente de plusieurs drogues et forçant un redémarrage du script pour pouvoir vendre à nouveau.
- Résolution d'un problème où le script ne permettait qu'une seule vente lorsque plusieurs types de drogues étaient configurés.

---

**Notes pour les développeurs :**
- Cette mise à jour permet la vente de plusieurs types de drogues sans qu'il soit nécessaire de redémarrer le script après chaque vente.
- Le système est désormais plus fluide et ne bloque plus après une première vente lorsqu'une seconde drogue est ajoutée à la configuration.